### PR TITLE
feat(word-processor): disable modal, add subtitle

### DIFF
--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it as test, vi } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
 
 import { Modal } from './Modal';
 
@@ -21,8 +21,23 @@ describe('Modal', () => {
     expect(screen.getByText('Modal Title')).toBeInTheDocument();
   });
 
+  test('should render the modal subtitle title', () => {
+    render(
+      <Modal
+        title="Modal Title"
+        subtitle="Modal subtitle"
+        handler={mockhandler}
+      />
+    );
+    expect(screen.getByText('Modal subtitle')).toBeInTheDocument();
+  });
+
   test('should call the handler function when save is clicked', () => {
     render(<Modal title="Modal Title" handler={mockhandler} />);
+
+    const input = screen.getByTestId('modalInput') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'test' } });
+
     screen.getByText('Save').click();
     expect(mockhandler).toHaveBeenCalled();
   });

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import { X } from 'phosphor-react';
 
 import Button from '../ToolBar/Button/Button';
@@ -7,12 +7,16 @@ import { useMarkdownStore } from '../../store/store';
 
 export function Modal({
   title,
+  subtitle,
   handler,
 }: {
   title: string;
+  subtitle?: string;
   handler: () => void;
 }) {
   const setFilename = useMarkdownStore((state) => state.setFileName);
+
+  const fileName = useMarkdownStore((state) => state.fileName);
 
   const toggleModalIsOpen = useMarkdownStore(
     (state) => state.toggleModalIsOpen
@@ -23,8 +27,9 @@ export function Modal({
   };
 
   const closeHandler = useCallback(() => {
+    setFilename('');
     toggleModalIsOpen();
-  }, [toggleModalIsOpen]);
+  }, [toggleModalIsOpen, setFilename]);
 
   const overlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
     event?.stopPropagation();
@@ -61,6 +66,16 @@ export function Modal({
     };
   }, [handler, closeHandler]);
 
+  const [disabled, setDisabled] = useState(true);
+
+  useEffect(() => {
+    if (fileName.length > 0) {
+      setDisabled(false);
+    } else {
+      setDisabled(true);
+    }
+  }, [fileName]);
+
   return (
     <div className="modal" data-testid="modal" onClick={overlayClick}>
       <div className="modalContainer">
@@ -71,13 +86,15 @@ export function Modal({
           <X />
         </div>
         <h2>{title}</h2>
+        <p>{subtitle}</p>
         <input
           data-testid="modalInput"
           type="text"
           onChange={onChangeHandler}
           ref={callbackRef}
+          required
         />
-        <Button text="Save" handler={handler} />
+        <Button text="Save" handler={handler} disabled={disabled} />
       </div>
     </div>
   );

--- a/src/components/ToolBar/ToolBar.tsx
+++ b/src/components/ToolBar/ToolBar.tsx
@@ -34,7 +34,11 @@ export default function ToolBar() {
   return (
     <>
       {modalIsOpen && (
-        <Modal title="Download your file" handler={saveFileHandler} />
+        <Modal
+          title="Download your file"
+          subtitle="Please enter a file name"
+          handler={saveFileHandler}
+        />
       )}
       <div className="toolBar" data-testid="toolBar">
         <h1 className="title">Markdown</h1>


### PR DESCRIPTION
Added functionality to make sure the save button cannot be clicked in the modal until a value is entered in the input field. 

Added an optional subtitle prop to the modal. 